### PR TITLE
[비밀번호 변경 API]

### DIFF
--- a/backend/connection.py
+++ b/backend/connection.py
@@ -73,3 +73,6 @@ class DatabaseConnection:
 
     def close(self):
         return self.db_connection.close()
+
+    def commit(self):
+        return self.db_connection.commit()

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,4 +1,4 @@
-from flask_script import Server, Manager
+from flask_script import Server
 from app import create_app
 
 if __name__ == "__main__":

--- a/backend/seller/service/seller_service.py
+++ b/backend/seller/service/seller_service.py
@@ -1,5 +1,7 @@
-from seller.model.seller_dao import SellerDao
+import bcrypt
+from flask import jsonify
 
+from seller.model.seller_dao import SellerDao
 
 class SellerService:
 
@@ -56,3 +58,92 @@ class SellerService:
 
         return get_all_sellers
 
+    def change_password(self, account_info, db_connection):
+
+        """ 계정 비밀번호 변경
+
+        account_info에 담긴 권한 정보를 확인하고,
+        마스터 권한일 경우
+        -> 비밀번호를 바로 변경해주며,
+        셀러 권한일 경우
+        -> 데코레이터에서 확인된 account_no 와 파라미터로 받은 account_no 가 일치하는지 확인하고,
+        비밀번호 변경
+
+        Args:
+            account_info: 엔드포인트에서 전달 받은 account 정보.
+            db_connection: 연결된 database connection 객체
+
+        Returns: http 응답코드
+            200: SUCCESS 비밀번호 변경 완료
+            400: INVALID_KEY
+            400: INVALID_AUTH_TYPE_ID
+            401: INVALID_PASSWORD
+            500: SERVER ERROR
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-03-31 (leejm3@brandi.co.kr) : 초기 생성
+            2020-04-01 (leejm3@brandi.co.kr) :
+            셀러의 경우 decorator account_no 와 parameter account_no이 일치하는 조건 추가
+
+        """
+        self.seller_dao = SellerDao()
+        try:
+            # Key 가 모두 들어오는지 확인하기 위해 새로운 dict 에 정보를 담음
+            new_account_info = {
+                'auth_type_id': account_info.get('auth_type_id', None),
+                'decorator_account_no': account_info.get('account_no', None),
+                'parameter_account_no': account_info.get('parameter_account_no', None),
+                'original_password': account_info.get('original_password', None),
+                'new_password': account_info.get('new_password', None)
+            }
+
+            # 계정이 가진 권한 타입을 가져옴
+            account_auth_type_id = new_account_info['auth_type_id']
+
+            # 마스터 권한일 때
+            if account_auth_type_id == 1:
+
+                # 인자로 전달 받은 새로운 비밀번호를 암호화 시킨 후 디코드 시켜 'new_password' 로 저장
+                crypted_password = bcrypt.hashpw(new_account_info['new_password'].encode('utf-8'), bcrypt.gensalt())
+                new_account_info['new_password'] = crypted_password.decode('utf-8')
+
+                # 새로운 비밀번호를 담아서 seller_dao 의 비밀번호 변경 dao 를 호출 및 반환
+                changing_password_result = self.seller_dao.change_password(new_account_info, db_connection)
+                return changing_password_result
+
+            # 셀러 권한일 때
+            elif account_auth_type_id == 2:
+
+                if new_account_info['decorator_account_no'] == new_account_info['parameter_account_no']:
+                    # DB 에서 기존에 저장되어있는 암호화된 비밀번호를 가져옴
+                    original_password = self.seller_dao.get_account_password(new_account_info, db_connection)
+
+                    # DB 에서 가져온 기존 비밀번호와 셀러가 입력한 기존 비밀번호가 일치하는지 확인
+                    if bcrypt.checkpw(new_account_info['original_password'].encode('utf-8'),
+                                      original_password['password'].encode('utf-8')):
+                        # 일치하는지 확인되면 새로운 비밀번호를 암호화해서 new_account_info 에 저장해줌
+                        crypted_password = bcrypt.hashpw(new_account_info['new_password'].encode('utf-8'),
+                                                         bcrypt.gensalt())
+                        new_account_info['new_password'] = crypted_password.decode('utf-8')
+
+                        # 새로운 비밀번호를 담아서 seller_dao 의 비밀번호 변경 dao 를 호출 및 반환
+                        changing_password_result = self.seller_dao.change_password(new_account_info, db_connection)
+                        return changing_password_result
+
+                    # 기존 비밀번호와 일치하지 않을 경우
+                    return jsonify({'message': 'INVALID_PASSWORD'}), 401
+
+                # decorator_account_no 와 parameter_account_no 가 다를 경우 비밀번호 변경 권한이 없음
+                else:
+                    return jsonify({'message': 'NO_AUTHORIZATION'}), 403
+
+            # 존재하지 않는 auth_type_id
+            else:
+                return jsonify({'message': 'INVALID_AUTH_TYPE_ID'}), 400
+
+        # Key 가 잘못 들어올 경우 None TypeError 가 뜨므로 에러 처리
+        except TypeError:
+            return jsonify({'message': 'INVALID_KEY'}), 400

--- a/backend/seller/view/seller_view.py
+++ b/backend/seller/view/seller_view.py
@@ -31,6 +31,7 @@ class SellerView:
             2020-03-25 (leesh3@brandi.co.kr): 초기 생성
             2020-03-30 (yoonhc@barndi.co.kr): database connection open & close 추가
         """
+
         db_connection = DatabaseConnection()
         if db_connection:
             try:
@@ -81,5 +82,60 @@ class SellerView:
                     db_connection.close()
                 except Exception as e:
                     return jsonify({'message': f'{e}'}), 400
+        else:
+            return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 400
+
+    # @login_decorator
+    @seller_app.route('/<int:account_no>', methods=['PUT'])
+    def change_password(account_no):
+        """ 계정 비밀번호 변경 엔드포인트
+
+        계정이 가진 권한에 따라 지정된 인자를 받아 비밀번호를 변경합니다.
+        url 에 비밀번호를 바꿔야할 계정 번호를 받습니다.
+
+        Parameters:
+            account_no: 비밀번호가 바뀌어야할 계정 번호
+
+        Request.body:
+            auth_type_id: 계정의 권한정보
+            account_no: 데코레이터에서 확인된 계정번호(데코레이더 생성되면 주석 제외_
+            original_password: 기존 비밀번호(마스터는 안보내줌)
+            new_password: 새로운 비밀번호
+
+        Returns: http 응답코드
+            200: SUCCESS 비밀번호 변경 완료
+            400: INVALID_KEY
+            400: INVALID_AUTH_TYPE_ID
+            401: INVALID_PASSWORD
+            500: SERVER ERROR
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-03-31 (leejm3@brandi.co.kr): 초기 생성
+        """
+
+        db_connection = DatabaseConnection()
+        if db_connection:
+            try:
+                # 데코레이터가 만들어지면, 데코레이터에서 account 정보 받아올 예정
+                account_info = request.json
+                account_info['parameter_account_no'] = account_no
+
+                seller_service = SellerService()
+
+                changing_password_result = seller_service.change_password(account_info, db_connection)
+                return changing_password_result
+
+            except Exception as e:
+                return jsonify({'message': f'{e}'}), 400
+
+            finally:
+                try:
+                    db_connection.close()
+                except Exception as e:
+                    return jsonify({'message': f'{e}'}), 400
+
         else:
             return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 400

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
-mysql
 alembic==1.4.2
+bcrypt==3.1.7
 boto3==1.12.31
 botocore==1.15.31
+cffi==1.14.0
 click==7.1.1
+cryptography==2.8
 docutils==0.15.2
 Flask==1.1.1
 Flask-Cors==3.0.8
@@ -13,10 +15,14 @@ Flask-SQLAlchemy==2.4.1
 itsdangerous==1.1.0
 Jinja2==2.11.1
 jmespath==0.9.5
+jwt==1.0.0
 Mako==1.1.2
 MarkupSafe==1.1.1
+mysql==0.0.2
 mysql-connector==2.2.9
 mysql-connector-repackaged==0.3.1
+mysqlclient==1.4.6
+pycparser==2.20
 python-dateutil==2.8.1
 python-editor==1.0.4
 s3transfer==0.3.3


### PR DESCRIPTION
- 셀러 등록/수정 페이지의 비밀번호 변경 API
- 데코레이터로부터 account_no와 account_auth_type_id를 전달 받고,
- url 파라미터로 변경하고자하는 account_no를 받고,
- 계정의 권한을 확인.
- 마스터 권한은 새로운 비밀번호를 입력하면 바로 변경해주고,
- 셀러 권한은 기존 비밀번호를 맞추는지 확인하고 비밀번호를 변경해줌
(현재는 포스트맨을 통해 request로 계정 정보를 받게 설계했고, 로그인,
데코레이터 기능이 완료되면 데코레이터를 통해 계정 정보를 받을 예정)

WIP