### PR TITLE
[셀러 정보 GET API 작성 / 비밀번호 변경 API 수정]

### DIFF
--- a/backend/seller/model/seller_dao.py
+++ b/backend/seller/model/seller_dao.py
@@ -208,7 +208,7 @@ class SellerDao:
         Returns: http 응답코드
             200: SUCCESS 비밀번호 변경 완료
             400: INVALID_KEY
-            500: SERVER ERROR
+            500: DB_CURSOR_ERROR, SERVER_ERROR
 
         Authors:
             leejm@brandi.co.kr (이종민)
@@ -238,7 +238,7 @@ class SellerDao:
 
                 # UPDATE 문 실행
                 db_cursor.execute(update_password_statement, account_info_data)
-                print(db_connection)
+
                 # 실행 결과 반영
                 db_connection.commit()
                 return jsonify({'message': 'SUCCESS'}), 200
@@ -250,3 +250,226 @@ class SellerDao:
             print(f'DATABASE_CURSOR_ERROR_WITH {e}')
             return jsonify({'message': 'DB_CURSOR_ERROR'}), 500
 
+    # noinspection PyMethodMayBeStatic
+    def get_seller_info(self, account_info, db_connection):
+
+        """ 계정의 셀러정보 표출
+
+        인자로 받아온 account_info['parameter_account_no'] 의 셀러정보를 표출합니다.
+
+        Args:
+            account_info: account 정보
+            (parameter_account_no: 셀러정보를 확인할 account_no)
+            db_connection: 연결된 database connection 객체
+
+        Returns:
+            200: 요청된 계정의 셀러정보
+            400: 존재하지 않는 계정 정보
+            500: DB_CURSOR_ERROR, SERVER_ERROR
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-03-31 (leejm3@brandi.co.kr): 초기 생성
+            2020-04-01 (leejm3@brandi.co.kr): seller_info 기본 정보 표출
+            2020-04-02 (leejm3@brandi.co.kr): 외래키 관련 정보 표출
+        """
+        try:
+            with db_connection as db_cursor:
+
+                # 셀러 기본 정보(외래키 제외)
+                # SELECT 문 조건 데이터
+                account_info_data = {
+                    'account_no': account_info['parameter_account_no']
+                }
+
+                # seller_info 테이블 SELECT (get 기본 정보)
+                select_seller_info_statement = """
+                    SELECT 
+                    seller_info_no,
+                    seller_account_id,
+                    profile_image_url,
+                    c.name as seller_status,
+                    d.name as seller_type,
+                    e.login_id,
+                    f.app_id as brandi_app_id,
+                    name_kr,
+                    name_en,
+                    brandi_app_user_id,
+                    ceo_name,
+                    company_name,
+                    business_number,
+                    certificate_image_url,
+                    online_business_number,
+                    online_business_image_url,
+                    background_image_url,
+                    short_description,
+                    site_url,
+                    insta_id,
+                    center_number,
+                    kakao_id,
+                    yellow_id,
+                    zip_code,
+                    address,
+                    detail_address,
+                    weekday_start_time,
+                    weekday_end_time,
+                    weekend_start_time,
+                    weekend_end_time,
+                    bank_name,
+                    bank_holder_name,
+                    account_number
+                    
+                    FROM seller_accounts AS a
+                    
+                    -- seller_info 기본 정보
+                    INNER JOIN seller_infos AS b
+                    ON a.seller_account_no = b.seller_account_id
+                    
+                    -- 셀러 상태명
+                    INNER JOIN seller_statuses as c
+                    ON b.seller_status_id = c.status_no
+                    
+                    -- 셀러 속성명
+                    INNER JOIN seller_types as d
+                    ON b.seller_type_id = d.seller_type_no                  
+                    
+                    -- 셀러계정 로그인 아이디
+                    LEFT JOIN accounts as e
+                    ON e.account_no = a.account_id
+                    AND e.is_deleted =0
+
+                    -- 브랜디 앱 아이디
+                    LEFT JOIN brandi_app_users as f
+                    ON b.brandi_app_user_id = f.app_user_no 
+                    AND f.is_deleted = 0
+                                                            
+                    WHERE a.account_id = %(account_no)s 
+                    AND a.is_deleted = 0
+                    ORDER BY b.seller_info_no DESC LIMIT 1
+                """
+
+                # SELECT 문 실행
+                db_cursor.execute(select_seller_info_statement, account_info_data)
+
+                # seller_info_result 에 쿼리 결과 저장
+                seller_info_result = db_cursor.fetchone()
+
+                # 담당자 정보
+                # SELECT 문 조건 데이터
+                seller_info_no_data = {
+                    'seller_info_no': seller_info_result['seller_info_no']
+                }
+                # manager_infos 테이블 SELECT(get *)
+                select_manager_infos_statement = """
+                                SELECT
+                                b.name,
+                                b.contact_number,
+                                b.email
+                                FROM seller_infos AS a
+                                INNER JOIN manager_infos AS b
+                                ON a.seller_info_no = b.seller_info_id
+                                WHERE seller_info_no = %(seller_info_no)s
+                                AND b.is_deleted = 0
+                                LIMIT 3
+                            """
+
+                # SELECT 문 실행
+                db_cursor.execute(select_manager_infos_statement, seller_info_no_data)
+
+                # manager_infos 출력 결과 저장
+                manager_infos = db_cursor.fetchall()
+
+                # seller_info_result 에 manager_info 저장
+                seller_info_result['manager_infos'] = [info for info in manager_infos]
+
+                # 셀러 상태 변경 기록
+                # SELECT 문 조건 데이터
+                account_info_data = {
+                    'seller_account_id': seller_info_result['seller_account_id']
+                }
+
+                # seller_status_change_histories 테이블 SELECT
+                select_status_history_statement = """
+                                SELECT
+                                changed_time,
+                                c.name as seller_status_name,
+                                d.login_id as modifier
+                                
+                                FROM
+                                seller_accounts as a
+                                
+                                -- 셀러상태이력 기본정보
+                                INNER JOIN
+                                seller_status_change_histories as b
+                                ON a.seller_account_no = b.seller_account_id
+                                
+                                -- 셀러 상태명
+                                INNER JOIN
+                                seller_statuses as c
+                                ON b.seller_status_id = c.status_no
+                                
+                                -- 수정자 로그인아이디
+                                LEFT JOIN
+                                accounts as d
+                                ON d.account_no = a.account_id
+                                
+                                WHERE a.seller_account_no = %(seller_account_id)s
+                                & d.is_deleted = 0
+                                
+                                ORDER BY changed_time                     
+                            """
+
+                # SELECT 문 실행
+                db_cursor.execute(select_status_history_statement, account_info_data)
+
+                # seller_status_change_histories 출력 결과 저장
+                status_histories = db_cursor.fetchall()
+
+                # seller_info_result 에 seller_status_change_histories 저장
+                seller_info_result['seller_status_change_histories'] = [history for history in status_histories]
+
+                # 셀러 속성 리스트(마스터가 셀러의 속성 변경하는 옵션 제공용)
+                # SELECT 문 조건 데이터
+                account_info_data = {
+                    'seller_info_no': seller_info_result['seller_info_no']
+                }
+
+                # seller_types 테이블 SELECT
+                select_seller_types_statement = """
+                                SELECT
+                                c.name as seller_types
+
+                                FROM 
+                                product_sorts as a
+                                
+                                INNER JOIN
+                                seller_infos as b
+                                ON a.product_sort_no = b.product_sort_id
+                                
+                                INNER JOIN
+                                seller_types as c
+                                ON a.product_sort_no = c.product_sort_id
+
+                                WHERE b.seller_info_no = %(seller_info_no)s
+                            """
+
+                # SELECT 문 실행
+                db_cursor.execute(select_seller_types_statement, account_info_data)
+
+                # seller_types 출력 결과 저장
+                seller_types = db_cursor.fetchall()
+
+                # seller_info_result 에 seller_types 저장
+                seller_info_result['seller_types'] = [seller_type['seller_types'] for seller_type in seller_types]
+
+                return seller_info_result
+
+        except KeyError as e:
+            print(f'KEY_ERROR WITH {e}')
+            return jsonify({'message': 'INVALID_KEY'}), 400
+
+        except Error as e:
+            print(f'DATABASE_CURSOR_ERROR_WITH {e}')
+            return jsonify({'message': 'DB_CURSOR_ERROR'}), 500

--- a/backend/seller/view/seller_view.py
+++ b/backend/seller/view/seller_view.py
@@ -4,6 +4,12 @@ from seller.service.seller_service import SellerService
 from connection import DatabaseConnection
 from utils import login_required
 
+from flask_request_validator import (
+    PATH,
+    JSON,
+    Param,
+    validate_params
+)
 
 class SellerView:
     """
@@ -85,48 +91,134 @@ class SellerView:
         else:
             return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 400
 
-    # @login_decorator
-    @seller_app.route('/<int:account_no>', methods=['PUT'])
-    def change_password(account_no):
+    @seller_app.route('/<int:parameter_account_no>', methods=['PUT'], endpoint='change_password')
+    @login_required
+    @validate_params(
+        Param('parameter_account_no', PATH, int),
+        Param('original_password', JSON, str, required=False),
+        Param('new_password', JSON, str),
+    )
+    def change_password(*args):
         """ 계정 비밀번호 변경 엔드포인트
 
         계정이 가진 권한에 따라 지정된 인자를 받아 비밀번호를 변경합니다.
         url 에 비밀번호를 바꿔야할 계정 번호를 받습니다.
+        Args:
+            * args:
+                parameter_account_no: 비밀번호가 바뀌어야할 계정 번호
 
-        Parameters:
-            account_no: 비밀번호가 바뀌어야할 계정 번호
-
-        Request.body:
+        g.account_info: 데코레이터에서 넘겨받은 계정 정보
             auth_type_id: 계정의 권한정보
-            account_no: 데코레이터에서 확인된 계정번호(데코레이더 생성되면 주석 제외_
+            account_no: 데코레이터에서 확인된 계정번호
+
+        request.body: request로 전달 받은 정보
             original_password: 기존 비밀번호(마스터는 안보내줌)
             new_password: 새로운 비밀번호
 
         Returns: http 응답코드
             200: SUCCESS 비밀번호 변경 완료
-            400: INVALID_KEY
-            400: INVALID_AUTH_TYPE_ID
+            400: VALIDATION_ERROR, INVALID_AUTH_TYPE_ID, NO_ORIGINAL_PASSWORD
             401: INVALID_PASSWORD
-            500: SERVER ERROR
+            500: DB_CURSOR_ERROR, SERVER_ERROR
 
         Authors:
             leejm3@brandi.co.kr (이종민)
 
         History:
             2020-03-31 (leejm3@brandi.co.kr): 초기 생성
+            2020-04-02 (leejm3@brandi.co.kr): 파라미터 validation 추가, 데코레이터 적용
         """
+
+        # validation 확인이 된 data 를 account_info 로 재정의
+        account_info = {
+            'parameter_account_no': args[0],
+            'original_password': args[1],
+            'new_password': args[2],
+            'auth_type_id': g.account_info['auth_type_id'],
+            'account_no': g.account_info['account_no'],
+
+        }
+
+        # 셀러 권한일 때 original_password 가 없으면 에러반환
+        if account_info['auth_type_id'] == 2:
+            if account_info['original_password'] is None:
+                return jsonify({"message": "NO_ORIGINAL_PASSWORD"}), 400
 
         db_connection = DatabaseConnection()
         if db_connection:
             try:
-                # 데코레이터가 만들어지면, 데코레이터에서 account 정보 받아올 예정
-                account_info = request.json
-                account_info['parameter_account_no'] = account_no
-
                 seller_service = SellerService()
-
                 changing_password_result = seller_service.change_password(account_info, db_connection)
                 return changing_password_result
+
+            except Exception as e:
+                return jsonify({'message': f'{e}'}), 400
+
+            finally:
+                try:
+                    db_connection.close()
+                except Exception as e:
+                    return jsonify({'message': f'{e}'}), 400
+
+        else:
+            return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 400
+
+    @seller_app.route('/<int:parameter_account_no>/info', methods=['GET'], endpoint='get_seller_info')
+    @login_required
+    @validate_params(
+        Param('parameter_account_no', PATH, int),
+     )
+    def get_seller_info(*args):
+
+        """ 계정 셀러정보 표출 엔드포인트
+
+        셀러정보를 표출하는 엔드포인트 입니다.
+        url 로 셀러정보를 확인하고 싶은 계정 번호를 받습니다.
+
+        Args:
+            * args:
+                parameter_account_no: 불러 올 셀러정보의 계정 번호
+        
+        g.account_info: 데코레이터에서 넘겨받은 계정 정보
+            auth_type_id: 계정의 권한정보
+            account_no: 데코레이터에서 확인된 계정번호
+
+        Returns: http 응답코드
+            # 200: SUCCESS 비밀번호 변경 완료
+            # 400: INVALID_KEY
+            # 400: VALIDATION_ERROR, INVALID_AUTH_TYPE_ID
+            # 401: INVALID_PASSWORD
+            # 500: SERVER ERROR
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-01 (leejm3@brandi.co.kr): 초기 생성
+            2020-04-02 (leejm3@brandi.co.kr): 파라미터 validation 추가, 데코레이터 적용
+        """
+
+        # validation 확인이 된 data 를 account_info 로 재정의
+        account_info = {
+            'parameter_account_no': args[0],
+            'auth_type_id': g.account_info['auth_type_id'],
+            'decorator_account_no': g.account_info['account_no'],
+        }
+
+        db_connection = DatabaseConnection()
+        if db_connection:
+            try:
+                seller_service = SellerService()
+
+                getting_seller_info_result = seller_service.get_seller_info(account_info, db_connection)
+
+                # 셀러정보가 존재하면 리턴
+                if getting_seller_info_result:
+                    return getting_seller_info_result
+
+                # 셀러정보가 None 으로 들어오면 INVALID_ACCOUNT_NO 리턴
+                else:
+                    return jsonify({'message': 'INVALID_ACCOUNT_NO'}), 400
 
             except Exception as e:
                 return jsonify({'message': f'{e}'}), 400

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ docutils==0.15.2
 Flask==1.1.1
 Flask-Cors==3.0.8
 Flask-Migrate==2.5.3
+flask-request-validator==2.1.2
 Flask-S3==0.3.3
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.1
@@ -23,6 +24,7 @@ mysql-connector==2.2.9
 mysql-connector-repackaged==0.3.1
 mysqlclient==1.4.6
 pycparser==2.20
+PyJWT==1.7.1
 python-dateutil==2.8.1
 python-editor==1.0.4
 s3transfer==0.3.3


### PR DESCRIPTION
[셀러 정보 GET API 작성]
- url로 셀러정보를 확인하고 싶은 계정 정보를 받고, decorator를 통해
정보를 확인하려고 시도하는 계정의 정보를 받음
- 마스터 권한의 경우 모든 계정의 정보를 볼 수 있게 하고, 셀러 계정의
경우 본인의 정보만 확인할 수 있게 함
- 'flask_request_validator' 모듈을 사용해 받는 파라미터들의 유효성을
확인함

[셀러 비밀번호 변경 수정]
- 데코레이터에서 비밀번호를 변경하려는 계정의 정보를 받음
- 셀러 정보 GET API와 같이 'flask_request_validator' 적용

[requirements.txt에 PyJWT 추가]