### PR TITLE
[GET - 기획전 타입 / 종류 목록 표출 API 생성 ]

### DIFF
--- a/backend/event/model/event_dao.py
+++ b/backend/event/model/event_dao.py
@@ -236,3 +236,97 @@ class EventDao:
             print(f'DATABASE_CURSOR_ERROR_WITH {e}')
             db_connection.rollback()
             return jsonify({'message': 'DB_CURSOR_ERROR'}), 500
+
+    # noinspection PyMethodMayBeStatic
+    def get_event_types(self, db_connection):
+
+        """ 기획전 타입 목록 표출
+
+        기획전 전체 타입 목록을 표출합니다.
+
+        Args:
+            db_connection: 데이터베이스 커넥션 객체
+
+        Returns:
+            200: 기획전 타입 목록
+            500: INVALID_KEY, DB_CURSOR_ERROR
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-09 (leejm3@brandi.co.kr): 초기 생성
+
+        """
+        try:
+            with db_connection.cursor() as db_cursor:
+                select_statement = """
+                    SELECT 
+                    event_type_no as event_type_id,
+                    name as event_type_name
+                    FROM event_types
+                    ORDER BY event_type_no
+                """
+
+                db_cursor.execute(select_statement)
+                types = db_cursor.fetchall()
+
+                return jsonify({'event_types': types}), 200
+
+        except KeyError as e:
+            print(f'KEY_ERROR_WITH {e}')
+            db_connection.rollback()
+            return jsonify({'message': 'INVALID_KEY'}), 500
+
+        except Error as e:
+            print(f'DATABASE_CURSOR_ERROR_WITH {e}')
+            db_connection.rollback()
+            return jsonify({'message': 'DB_CURSOR_ERROR'}), 500
+
+    # noinspection PyMethodMayBeStatic
+    def get_event_sorts(self, event_type_info, db_connection):
+
+        """ 기획전 타입별 종류 목록 표출
+
+        기획전 특정 타입별 종류 목록을 표출합니다.
+
+        Args:
+            event_type_info: 이벤트 타입 정보
+            db_connection: 데이터베이스 커넥션 객체
+
+        Returns:
+            200: 기획전 타입 목록
+            500: INVALID_KEY, DB_CURSOR_ERROR
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-09 (leejm3@brandi.co.kr): 초기 생성
+
+        """
+        try:
+            with db_connection.cursor() as db_cursor:
+                select_statement = """
+                    SELECT 
+                    event_sort_no as event_sort_id,
+                    name as event_sort_name
+                    FROM event_sorts
+                    WHERE event_type_id = %(event_type_id)s
+                    ORDER BY event_sort_no
+                """
+
+                db_cursor.execute(select_statement, event_type_info)
+                sorts = db_cursor.fetchall()
+
+                return jsonify({'event_sorts': sorts}), 200
+
+        except KeyError as e:
+            print(f'KEY_ERROR_WITH {e}')
+            db_connection.rollback()
+            return jsonify({'message': 'INVALID_KEY'}), 500
+
+        except Error as e:
+            print(f'DATABASE_CURSOR_ERROR_WITH {e}')
+            db_connection.rollback()
+            return jsonify({'message': 'DB_CURSOR_ERROR'}), 500

--- a/backend/event/service/event_service.py
+++ b/backend/event/service/event_service.py
@@ -53,3 +53,57 @@ class EventService:
 
         except Exception as e:
             return jsonify({'message': f'{e}'}), 400
+
+    # noinspection PyMethodMayBeStatic
+    def get_event_types(self, db_connection):
+
+        """ 기획전 타입 목록 표출
+
+        기획전 전체 타입 목록을 표출합니다.
+
+        Args:
+            db_connection: 데이터베이스 커넥션 객체
+
+        Returns:
+            200: 기획전 타입 목록
+            500: DB_CURSOR_ERROR, INVALID_KEY
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-09 (leejm3@brandi.co.kr): 초기 생성
+
+        """
+
+        event_dao = EventDao()
+        types = event_dao.get_event_types(db_connection)
+
+        return types
+
+    # noinspection PyMethodMayBeStatic
+    def get_event_sorts(self, event_type_info, db_connection):
+        """ 기획전 타입별 종류 목록 표출
+
+        기획전 특정 타입별 종류 목록을 표출합니다.
+
+        Args:
+            event_type_info: 이벤트 타입 정보
+            db_connection: 데이터베이스 커넥션 객체
+
+        Returns:
+            200: 기획전 타입별 종류 목록
+            500: DB_CURSOR_ERROR, INVALID_KEY
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-09 (leejm3@brandi.co.kr): 초기 생성
+
+        """
+
+        event_dao = EventDao()
+        sorts = event_dao.get_event_sorts(event_type_info, db_connection)
+
+        return sorts

--- a/backend/event/view/event_view.py
+++ b/backend/event/view/event_view.py
@@ -209,3 +209,98 @@ class EventView:
                     return jsonify({'message': f'{e}'}), 400
         else:
             return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 500
+
+    @event_app.route("/type", methods=["GET"])
+    @login_required
+    def get_event_types():
+
+        """ 기획전 타입 표출 엔드포인트
+
+        기획전 타입 표출 엔드포인트 입니다.
+        기획전 등록페이지에서 기획전 타입 목록을 표출할때 사용됩니다.
+
+        Returns:
+            200: 기획전 타입 목록
+            500: DB_CURSOR_ERROR, INVALID_KEY, NO_DATABASE_CONNECTION
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-09 (leejm3@brandi.co.kr): 초기 생성
+
+        """
+
+        db_connection = get_db_connection()
+        if db_connection:
+            try:
+                event_service = EventService()
+                types = event_service.get_event_types(db_connection)
+
+                return types
+
+            except Exception as e:
+                return jsonify({'message': f'{e}'}), 400
+
+            finally:
+                try:
+                    db_connection.close()
+
+                except Exception as e:
+                    return jsonify({'message': f'{e}'}), 400
+        else:
+            return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 500
+
+    @event_app.route("/type/<int:event_type_id>", methods=["GET"], endpoint='get_event_sorts')
+    @login_required
+    @validate_params(
+        Param('event_type_id', PATH, str,
+              rules=[Pattern(r"^[1-5]{1}$")])
+    )
+    def get_event_sorts(*args):
+
+        """ 기획전 타입별 종류 표출 엔드포인트
+
+        기획전 타입별 종류 표출 엔드포인트 입니다.
+        기획전 등록페이지에서 기획전 타입 별 목록을 표출할때 사됩니다.
+
+        Args:
+            *args: 유효성 검사를 통과한 파라미터
+
+        url Parameter:
+            event_type_id: 기획전 타입 아이디
+
+        Returns:
+            200: 기획전 타입별 종류 목록
+            500: DB_CURSOR_ERROR, INVALID_KEY, NO_DATABASE_CONNECTION
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-09 (leejm3@brandi.co.kr): 초기 생성
+
+        """
+
+        # event_type_id 저장
+        event_type_info = {"event_type_id": args[0]}
+
+        db_connection = get_db_connection()
+        if db_connection:
+            try:
+                event_service = EventService()
+                sorts = event_service.get_event_sorts(event_type_info, db_connection)
+
+                return sorts
+
+            except Exception as e:
+                return jsonify({'message': f'{e}'}), 400
+
+            finally:
+                try:
+                    db_connection.close()
+
+                except Exception as e:
+                    return jsonify({'message': f'{e}'}), 400
+        else:
+            return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 500


### PR DESCRIPTION
- 기획전 등록페이지에서 사용되는 기획전 타입 / 종류 목록 표출 API 작성
- 기획전 타입은 전체 표출되고, 기획전 종류는 url parameter로 받은 기획전 타입에 따라 특정 종류 목록이 표출됨