### PR TITLE
[GET - 기획전 수정페이지 정보 표출]

### DIFF
--- a/backend/event/service/event_service.py
+++ b/backend/event/service/event_service.py
@@ -92,11 +92,14 @@ class EventService:
             2020-04-09 (leejm3@brandi.co.kr): 초기 생성
 
         """
+        try:
+            event_dao = EventDao()
+            types = event_dao.get_event_types(db_connection)
 
-        event_dao = EventDao()
-        types = event_dao.get_event_types(db_connection)
+            return types
 
-        return types
+        except Exception as e:
+            return jsonify({'message': f'{e}'}), 400
 
     # noinspection PyMethodMayBeStatic
     def get_event_sorts(self, event_type_info, db_connection):
@@ -120,7 +123,43 @@ class EventService:
 
         """
 
-        event_dao = EventDao()
-        sorts = event_dao.get_event_sorts(event_type_info, db_connection)
+        try:
+            event_dao = EventDao()
+            sorts = event_dao.get_event_sorts(event_type_info, db_connection)
 
-        return sorts
+            return sorts
+
+        except Exception as e:
+            return jsonify({'message': f'{e}'}), 400
+
+    # noinspection PyMethodMayBeStatic
+    def get_event_infos(self, event_no, db_connection):
+
+        """ 기획전 정보 표출 로직
+
+        전달 받은 기획전 번계정번호에 맞는 셀러정보를 표출해줍니다.
+
+        Args:
+            event_no: 기획전 번호
+            db_connection: 연결된 database connection 객체
+
+        Returns: http 응답코드
+            200: 기획전 정보
+            400: INVALID_EVENT_NO
+            500: DB_CURSOR_ERROR, INVALID_KEY
+
+        Authors:
+            leejm3@brandi.co.kr (이종민)
+
+        History:
+            2020-04-10 (leejm3@brandi.co.kr) : 초기 생성
+
+        """
+
+        event_dao = EventDao()
+        try:
+            getting_event_info_result = event_dao.get_event_infos(event_no, db_connection)
+            return getting_event_info_result
+
+        except Exception as e:
+            return jsonify({'message': f'{e}'}), 400

--- a/backend/seller/view/seller_view.py
+++ b/backend/seller/view/seller_view.py
@@ -472,7 +472,6 @@ class SellerView:
         # 이미지 업로드 함수를 호출해서 이미지를 업로드하고 url을 사전형으로 가져옴.
         image_upload = ImageUpload()
         seller_image = image_upload.upload_seller_image(request)
-        print(seller_image)
 
         # validation 확인이 된 data 를 account_info 로 재정의
         account_info = {


### PR DESCRIPTION
- 전체 기획전 타입에 공통으로 사용되는 부분 작성 -> 추가 상품이 붙는 상품(이미지,텍스트), 유튜브 타입은 추가 작성 필요
- 기획전 수정 페이지에서 기존 정보를 불러오는 GET API
- 마스터 권한일 경우에만 get 할 수 있고, 해당 기획전 번호의 결과값이 존재하지 않으면 INVALID_EVENT_NO를 반환함

[POST - 기획전 등록 페이지에서 필수값 유효성 로직 수정]
- event_sort_type_id 등의 필수값은 이미 parameter validator에서 확인되고 있으므로 추가로 작성된 부분 삭제