### PR TITLE
[기획전 수정페이지 GET]

### DIFF
--- a/backend/event/service/event_service.py
+++ b/backend/event/service/event_service.py
@@ -170,7 +170,8 @@ class EventService:
         """ 기획전 수정 로직
 
         event_info 에 담긴 기획전 타입을 확인하고,
-        각 기획전에 맞는 필드를 등록하는 dao 를 실행함
+        각 기획전 타입에 들어오지 말아야 할 키값을 걸러줌.
+        기획전타입확인과 유효성검사가 끝나면 dao로 arguments를 넘김.
 
         Args:보
             event_info: 유효성 검사를 통과한 기획전 등록 정보
@@ -179,42 +180,104 @@ class EventService:
 
         Returns: http 응답코드
             200: SUCCESS 기획전 수정 완료
-            400: NOT_ALLOWED_TO_CHANGE_EVENT_TYPE_OR_SORT, INVALID_EVENT_NO
+            400: NOT_ALLOWED_TO_CHANGE_EVENT_TYPE_OR_SORT,
+                INVALID_EVENT_NO,
+                INVALID_FIELD_LONG_DESCRIPTION,
+                INVALID_FIELD_SHORT_DESCRIPTION,
+                INVALID_FIELD_YOUTUBE_URL,
+                INVALID_FILED_EVENT_PRODUCT,
+                INVALID_FIELD_BUTTON,
+                INVALID_FIELD_BANNER_IMAGE_URL,
+                INVALID_FIELD_DETAIL_IMAGE_URL,
             500: DB_CURSOR_ERROR, INVALID_KEY
 
         Authors:
             leejm3@brandi.co.kr (이종민)
+            yoonhc@brandi.co.kr (윤희철)
 
         History:
             2020-04-10 (leejm3@brandi.co.kr): 초기생성
+            2020-04-11 (yoonhc@brandi.co.kr): 각 기획전 타입별 들어오지 말아야할 키값을 걸러주는 로직 추가.
 
         """
-
+        print(event_info)
         event_dao = EventDao()
         try:
             # 기획전 타입이 이벤트일 경우
             if event_info['event_type_id'] == 1:
-                changing_event_result = event_dao.change_event_event(event_info, db_connection)
+
+                # 기획전 이벤트에 들어오면 안되는 필드를 걸러줌.
+                if event_info['long_description']:
+                    return jsonify({'message': 'INVALID_FIELD_LONG_DESCRIPTION'}), 400
+                if event_info['youtube_url']:
+                    return jsonify({'message': 'INVALID_FIELD_YOUTUBE_URL'}), 400
+                if event_product_info:
+                    return jsonify({'message': 'INVALID_FILED_EVENT_PRODUCT'}), 400
+
+                # 통과되면(기획전 타입이 이벤트로 판명되면) dao로 arguments를 넘겨줌.
+                changing_event_result = event_dao.change_event(event_info, db_connection, event_product_info)
                 return changing_event_result
 
             # 기획전 타입이 쿠폰일 경우
             if event_info['event_type_id'] == 2:
-                changing_event_result = event_dao.change_coupon_event(event_info, db_connection)
+                if event_info['banner_image_url']:
+                    return jsonify({'message': 'INVALID_FIELD_BANNER_IMAGE_URL'}), 400
+                if event_info['detail_image_url']:
+                    return jsonify({'message': 'INVALID_FIELD_DETAIL_IMAGE_URL'}), 400
+                if event_info['youtube_url']:
+                    return jsonify({'message': 'INVALID_FIELD_YOUTUBE_URL'}), 400
+                if event_product_info:
+                    return jsonify({'message': 'INVALID_FILED_EVENT_PRODUCT'}), 400
+
+                # 통과되면(기획전타입이 쿠폰으로 판명되면) dao로 arguments를 넘겨줌
+                changing_event_result = event_dao.change_event(event_info, db_connection, event_product_info)
                 return changing_event_result
 
             # 기획전 타입이 상품(이미지)일 경우
             if event_info['event_type_id'] == 3:
-                changing_event_result = event_dao.change_product_image_event(event_info, event_product_info, db_connection)
+
+                # 기획전 값이 상품이미지 일 경우 들어오지 말아야 할 키값을 걸러줌.
+                if event_info['long_description']:
+                    return jsonify({'message': 'INVALID_FIELD_LONG_DESCRIPTION'}), 400
+                if event_info['short_description']:
+                    return jsonify({'message': 'INVALID_FIELD_SHORT_DESCRIPTION'}), 400
+                if event_info['youtube_url']:
+                    return jsonify({'message': 'INVALID_FIELD_YOUTUBE_URL'}), 400
+                if event_info['button_name'] or event_info['button_link_type_id'] or event_info['button_link_description']:
+                    return jsonify({'message': 'INVALID_FIELD_BUTTON'}), 400
+
+                # 통과되면(기획전 타입이 상품이미지로 판명되면) dao로 arguments를 넘겨줌.
+                changing_event_result = event_dao.change_event(event_info, db_connection, event_product_info)
                 return changing_event_result
 
             # 기획전 타입이 상품(텍스트)일 경우
             if event_info['event_type_id'] == 4:
-                changing_event_result = event_dao.change_product_text_event(event_info, event_product_info, db_connection)
+
+                # 기획전 타입이 상품텍스트 일 때 들어오지 말아야 할 키값을 걸러줌.
+                if event_info['youtube_url']:
+                    return jsonify({'message': 'INVALID_FIELD_YOUTUBE_URL'}), 400
+                if event_info['button_name'] or event_info['button_link_type_id'] or event_info['button_link_description']:
+                    return jsonify({'message': 'INVALID_FIELD_BUTTON'}), 400
+                if event_info['detail_image_url']:
+                    return jsonify({'message': 'INVALID_FIELD_DETAIL_IMAGE_URL'}), 400
+                if event_info['long_description']:
+                    return jsonify({'message': 'INVALID_FIELD_LONG_DESCRIPTION'}), 400
+
+                # 통과되면(기획전 타입이 상품텍스트로 판명되면) dao로 arguments를 넘겨줌.
+                changing_event_result = event_dao.change_event(event_info, db_connection, event_product_info)
                 return changing_event_result
 
             # 기획전 타입이 유튜브일 경우
             if event_info['event_type_id'] == 5:
-                changing_event_result = event_dao.change_youtube_event(event_info,event_product_info, db_connection)
+
+                # 기획전 타입이 유튜브일 때 들어오지 말아야 할 키값들을 걸러줌.
+                if event_info['button_name'] or event_info['button_link_type_id'] or event_info['button_link_description']:
+                    return jsonify({'message': 'INVALID_FIELD_BUTTON'}), 400
+                if event_info['long_description']:
+                    return jsonify({'message': 'INVALID_FIELD_LONG_DESCRIPTION'}), 400
+
+                # 통과되면(기획전 타입이 유튜브로 판명되면) dao로 arguments를 넘겨줌.
+                changing_event_result = event_dao.change_event(event_info, db_connection, event_product_info)
                 return changing_event_result
 
         except TypeError as e:

--- a/backend/event/view/event_view.py
+++ b/backend/event/view/event_view.py
@@ -357,6 +357,7 @@ class EventView:
 
         Authors:
             leejm3@brandi.co.kr (이종민)
+            yoonhc@brandi.co.kr (윤희철)
 
         History:
             2020-04-10 (leejm3@brandi.co.kr): 초기 생성
@@ -423,7 +424,7 @@ class EventView:
               rules=[Pattern(r"^[1-6]{1}$")]),
         Param('button_link_description', FORM, str, required=False,
               rules=[MaxLength(45)]),
-        Param('product', FORM, list, required=False),
+        Param('product', FORM, str, required=False),
         Param('youtube_url', FORM, str, required=False,
               rules=[Pattern(r"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$")]),
         Param('youtube_url', FORM, str, required=False,
@@ -479,9 +480,13 @@ class EventView:
 
         Authors:
             leejm3@brandi.co.kr (이종민)
+            yoonhc@brandi.co.kr (윤희철)
 
         History:
             2020-04-10 (leejm3@brandi.co.kr): 초기 생성
+            2020-04-11 (yoonhc@brandi.co.kr):
+                - utils.py에서 나오는 결과값에 애러코드 400이있으면 애러메세지를 그대로 리턴하는 코드 추가
+                - 기획전 상품이 validation을 통과하면 json loads를 통해서 array자료형으로 파싱하는 코드 추가.
 
         """
 
@@ -492,6 +497,10 @@ class EventView:
         # 이미지 업로드 함수를 호출해서 이미지를 업로드하고 url을 사전형으로 가져옴.
         image_upload = ImageUpload()
         event_image = image_upload.upload_event_image(request)
+
+        # 함수의 실행결과에 400이 포함된 경우 애러메세지를 그대로 리턴함.
+        if (400 or 500) in event_image:
+            return event_image
 
         # validation(형식) 확인된 데이터 저장
         event_info = {
@@ -505,7 +514,7 @@ class EventView:
             'event_end_time': args[7],
             'short_description': args[8],
             'long_description': args[9],
-            'banner_image_url': event_image.get('s3_banner_imager_url', None),
+            'banner_image_url': event_image.get('s3_banner_image_url', None),
             'detail_image_url': event_image.get('s3_detail_image_url', None),
             'button_name': args[14],
             'button_link_type_id': args[15],
@@ -522,8 +531,13 @@ class EventView:
         if not event_info['detail_image_url']:
             event_info['detail_image_url'] = args[12]
 
-        # 리스트로 들어온 product 정보를 따로 저장 (dao 에서 에러를 막기 위해)
-        event_product_info = args[17]
+        # 리스트로 들어온 product 정보를 따로 저장 (dao 에서 에러를 막기 위해), 값이 안들어오면 None으로 넘겨줌.
+        try:
+            # form데이터로 값을 받으면 str처리가 되기 때문에 json.loads통해서 array 자료형으로 만들어준다.
+            event_product_info = json.loads(args[17])
+        except:
+            # form data로 값이 들어오지 않으면 None type을 파싱하는 경우가 생기기 때문에 except처리를 넣고 넘겨줄 값에 None을 담는다.
+            event_product_info = None
 
         # 기획전 기간 밸리데이션
         now = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M')
@@ -602,13 +616,13 @@ class EventView:
                 return info
 
             except Exception as e:
-                return jsonify({'message': f'{e}'}), 400
+                return jsonify({'view_message': f'{e}'}), 400
 
             finally:
                 try:
                     db_connection.close()
 
                 except Exception as e:
-                    return jsonify({'message': f'{e}'}), 400
+                    return jsonify({'view_message': f'{e}'}), 400
         else:
-            return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 500
+            return jsonify({'view_message': 'NO_DATABASE_CONNECTION'}), 500

--- a/backend/product/view/product_view.py
+++ b/backend/product/view/product_view.py
@@ -308,6 +308,10 @@ class ProductView():
         image_uploader = ImageUpload()
         uploaded_images = image_uploader.upload_product_image(request)
 
+        # 이미지 업로더를 호출한 결과값에 애러코드 400이 포함되어있으면 utils.py에서 발생한 러메세지를 그대로 리턴
+        if (400 or 500) in uploaded_images:
+            return uploaded_images
+
         product_info = {
             'auth_type_id': g.account_info['auth_type_id'],
             'token_account_no': g.account_info['account_no'],

--- a/backend/schema/brandi_schema_v2.1.sql
+++ b/backend/schema/brandi_schema_v2.1.sql
@@ -1824,14 +1824,6 @@ INSERT INTO events (
 (
     8, -- event_no
     4 -- uploader
-),
-(
-    9, -- event_no
-    5 -- uploader
-),
-(
-    10, -- event_no
-    6 -- uploader
 );
 
 
@@ -1895,33 +1887,33 @@ INSERT INTO event_infos
 	event_id
 ) VALUES (
 	1, -- event_info_no
-	'이벤트1', -- name
+	'이벤트1 이벤트', -- name
 	1, -- is_on_main
 	1, -- is_on_event
-	'브랜디 이벤트1 입니다.', -- short_description
+	'브랜디 기획전 이벤트타입 입니다.', -- short_description
 	'2020-03-21 23:59:59', -- event_stat_time
 	'2020-04-21 23:59:59', -- event_end_time
 	'https://image.brandi.me/home/banner/bannerImage_1_1585288803.jpg', -- banner_image_url
 	'https://image.brandi.me/event/2020/03/27/1585274063_bannerdetail.jpg', -- detail_image_url
-	'<p>브랜디 이벤트1 입니다. 장문의 상세 설명입니다.</p>', -- long_description
-	'https://youtu.be/hyZsbD7SIu4', -- youtube_url
-	1, -- event_type_id
+	NULL, -- long_description
+	NULL, -- youtube_url
+	1, -- event_type_id, 이벤트타입
 	1, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=1), -- start_time
 	1, -- modifier, account_no
 	1 -- event_id
 ),(
 	2, -- event_info_no
-	'이벤트2', -- name
+	'이벤트2 쿠폰', -- name
 	1, -- is_on_main
 	1, -- is_on_event
-	'브랜디 이벤트2 입니다.', -- short_description
-	'2020-03-27 23:59:59', -- event_stat_time
+	'브랜디 쿠폰 이벤트2 입니다.', -- short_description
+	'2020-03-27 23:59:59', -- event_start_time
 	'2020-04-19 23:59:59', -- event_end_time
-	'https://image.brandi.me/home/banner/bannerImage_5_1585274842.jpg', -- banner_image_url
-	'https://image.brandi.me/event/2020/03/22/1584847404_bannerdetail.jpg', -- detail_image_url
+	NULL, -- banner_image_url
+	NULL, -- detail_image_url
 	'<p>브랜디 이벤트2 입니다. 장문의 상세 설명입니다.</p>', -- long_description
-	'https://youtu.be/hyZsbD7SIu4', -- youtube_url
+	NULL, -- youtube_url
 	2, -- event_type_id
 	3, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=2), -- start_time
@@ -1929,16 +1921,16 @@ INSERT INTO event_infos
 	2 -- event_id
 ),(
 	3, -- event_info_no
-	'이벤트3', -- name
+	'이벤트3 쿠폰', -- name
 	1, -- is_on_main
 	1, -- is_on_event
 	'브랜디 이벤트3 입니다.', -- short_description
 	'2020-03-27 23:59:59', -- event_stat_time
 	'2020-04-19 23:59:59', -- event_end_time
-	'https://image.brandi.me/home/banner/bannerImage_126197_1585534030.jpg', -- banner_image_url
-	'https://image.brandi.me/event/2020/03/29/1585460313_bannerdetail.jpg', -- detail_image_url
+	null, -- banner_image_url
+	null, -- detail_image_url
 	'<p>브랜디 이벤트3 입니다. 장문의 상세 설명입니다.</p>', -- long_description
-	'https://youtu.be/XqGjahLSYR0', -- youtube_url
+	null, -- youtube_url
 	2, -- event_type_id
 	3, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=3), -- start_time
@@ -1946,16 +1938,16 @@ INSERT INTO event_infos
 	3 -- event_id
 ),(
 	4, -- event_info_no
-	'이벤트4', -- name
+	'이벤트4 쿠폰', -- name
 	1, -- is_on_main
 	1, -- is_on_event
 	'브랜디 이벤트4 입니다.', -- short_description
 	'2020-03-27 23:59:59', -- event_stat_time
 	'2020-04-19 23:59:59', -- event_end_time
-	'https://image.brandi.me/home/banner/bannerImage_126162_1585534016.jpg', -- banner_image_url
-	'https://image.brandi.me/event/2020/03/27/1585300626_bannerdetail.jpg', -- detail_image_url
+	null, -- banner_image_url
+	null, -- detail_image_url
 	'<p>브랜디 이벤트4 입니다. 장문의 상세 설명입니다.</p>', -- long_description
-	'https://youtu.be/jVTc9c3j8R4', -- youtube_url
+	null, -- youtube_url
 	2, -- event_type_id
 	3, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=4), -- start_time
@@ -1963,7 +1955,7 @@ INSERT INTO event_infos
 	4 -- event_id
 ),(
 	5, -- event_info_no
-	'이벤트4', -- name
+	'이벤트4 상품이미지', -- name
 	1, -- is_on_main
 	1, -- is_on_event
 	NULL, -- short_description
@@ -1977,10 +1969,10 @@ INSERT INTO event_infos
 	9, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=7), -- start_time
 	2, -- modifier, account_no
-	7 -- event_id
+	5 -- event_id
 ),(
 	6, -- event_info_no
-	'이벤트4', -- name
+	'이벤트4 상품이미지', -- name
 	1, -- is_on_main
 	1, -- is_on_event
 	NULL, -- short_description
@@ -1994,10 +1986,10 @@ INSERT INTO event_infos
 	10, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=8), -- start_time
 	2, -- modifier, account_no
-	8 -- event_id
+	6 -- event_id
 ),(
 	7, -- event_info_no
-	'이벤트4', -- name
+	'이벤트4 상품텍스트', -- name
 	1, -- is_on_main
 	1, -- is_on_event
 	'브랜디 이벤트4 입니다.', -- short_description
@@ -2005,16 +1997,16 @@ INSERT INTO event_infos
 	'2020-04-19 23:59:59', -- event_end_time
 	'https://image.brandi.me/home/banner/bannerImage_126162_1585534016.jpg', -- banner_image_url
 	NULL, -- detail_image_url
-	'<p>브랜디 이벤트4 입니다. 장문의 상세 설명입니다.</p>', -- long_description
-	'https://youtu.be/jVTc9c3j8R4', -- youtube_url
+	null, -- long_description
+	null, -- youtube_url
 	4, -- event_type_id
 	11, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=9), -- start_time
 	2, -- modifier, account_no
-	9 -- event_id
+	7 -- event_id
 ),(
 	8, -- event_info_no
-	'이벤트4', -- name
+	'이벤트4 유튜브', -- name
 	1, -- is_on_main
 	1, -- is_on_event
 	'브랜디 이벤트4 입니다.', -- short_description
@@ -2028,7 +2020,7 @@ INSERT INTO event_infos
 	13, -- event_sort_id
 	(SELECT created_at FROM events WHERE event_no=10), -- start_time
 	2, -- modifier, account_no
-	10 -- event_id
+	8 -- event_id
 );
 
 

--- a/backend/seller/view/seller_view.py
+++ b/backend/seller/view/seller_view.py
@@ -421,7 +421,7 @@ class SellerView:
 
         Authors:
             leejm3@brandi.co.kr (이종민)
-            yoonhc@brandi.co.kr
+            yoonhc@brandi.co.kr (윤희철)
 
         History:
             2020-04-03 (leejm3@brandi.co.kr): 초기 생성
@@ -431,7 +431,7 @@ class SellerView:
             2020-04-08 (leejm3@brandi.co.kr):
                 마스터가 아닐 때 셀러 상태(입점 등)를 변경하려고 하면 에러 처리하는 내용 추가
             2020-04-09 (yoonhc@barndi.co.kr):
-                이미지 업로더 적용
+                이미지 업로더 적용.
             2020-04-09 (leejm3@brandi.co.kr):
                  이미지 파일을 새로 업로드하면, 이 파일을 저장한 s3 url 을 저장하고,
                  수정을 안해서 기존에 DB에 저장된 url 을 보내주면, 해당 url 을 저장함
@@ -472,6 +472,9 @@ class SellerView:
         # 이미지 업로드 함수를 호출해서 이미지를 업로드하고 url을 사전형으로 가져옴.
         image_upload = ImageUpload()
         seller_image = image_upload.upload_seller_image(request)
+
+        if (400 or 500) in seller_image:
+            return seller_image
 
         # validation 확인이 된 data 를 account_info 로 재정의
         account_info = {


### PR DESCRIPTION
- 기획전 타입이 상품이미지, 상품텍스트, 유튜브 일 경우 기획전 상품정보를 데이터베이스에서 가져옴.

[셀러 리스트 GET]
- 쿼리파라미터로 키워드가 들어올 경우 필터링된 셀러의 수를 count하여 리턴값에 포함해주는 기능 추가.

[기획전 수정 PUT]
- 기획전 정보 테이블에 새로운 이력 생성.
- 새로운 이력을 만들어주기 전 해당 기획전 id값을 가지는 가장 최근의 기획전 정보의 선분을 현시간으로 끊어줌.
- 각 기획전 타입별 유효성 검사 후 통과한  arguments로 기획전 정보 테이블에 새로운 이력 생성
- 기획전 타입이 이벤트, 쿠폰인 경우 버튼 테이블에 새로생성된 기획전 정보를 foreign key로 가지는 새로운 row추가.
- 기획전 타입이 상품이미지, 상품텍스트, 유튜브인 경우 기획전 상품테이블에 새로생성된 기획전 정보를
- foreign key로 가지는 새로운 row추가.(기획전상품 값이 들어온 경우에 한함.)

[이미지 업로더]
- s3에 올릴때 뜨는 애러 catch하는 코드 추가
- utils.py에서 나오는 결과값에 애러코드가 있으면 애러메세지를 그대로 리턴하는 코드 추가